### PR TITLE
Add README for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,45 @@
+# OctoAcme Project Management Docs
 
+This repository section provides a high-level overview of project management practices at OctoAcme and direct links to all process documents. Use this README as your starting point for navigating the program’s standardized, collaborative, and customer-focused approach.
+
+---
+
+## Project Management Processes: Overview
+
+OctoAcme runs projects through clear, iterative, and evidence-driven processes. We prioritize:
+- Customer-first, data-informed decisions
+- Transparent roles and responsibilities
+- Risk awareness and effective communication
+- Iterative delivery and continuous improvement
+
+Project lifecycle stages:
+1. **Initiation:** Clear problem definition, goals, stakeholder alignment, initial plan.
+2. **Planning:** Actionable backlog, dependency/risk identification, timeline and ownership.
+3. **Execution & Tracking:** Team ceremonies, code/review/test workflows, status transparency.
+4. **Risk & Communication:** Ongoing risk management and stakeholder communication.
+5. **Release & Deployment:** Safe, documented releases with quality checks and incident playbooks.
+6. **Retrospective & Improvement:** Regular reviews, action items, and culture of learning.
+7. **Roles & Personas:** Clear role expectations and communication norms.
+
+---
+
+## Process Documentation:
+
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](./octoacme-roles-and-personas.md)
+
+---
+
+> For onboarding, start with the [Project Management Overview](./octoacme-project-management-overview.md).  
+> Each process document details specific steps, templates, and accepted practices.
+
+---
+
+_This README and accompanying docs help OctoAcme ensure consistent, collaborative, and transparent project execution.  
+For suggested updates, use the issue template in `.github/ISSUE_TEMPLATE`._


### PR DESCRIPTION
-     Adds docs/octoacme-project-management-readme.md as a single entry point for Project Management docs.
-     Includes a brief overview of OctoAcme's project management approach and links to all existing process documents in docs/.
-     Improves onboarding and discoverability of process artifacts.
resolves #2
